### PR TITLE
In order search

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,9 +206,10 @@ impl<T: PartialOrd + Ord + Clone> BinaryTree<T> {
         }
     }
 
-    //WIP
-    //Creates linked list with references to binary search tree ordered from min to max
     //Iterator workaround
+    //Creates linked list with references to binary search tree ordered from min to max
+    //To achieve this Binary tree traversal is done in Reverse order 
+    //Because LinkedList push implementation adds new nodes atop, not in the end of List
     pub fn flatten(&self) -> LinkedList<T> {
         let mut flattened_bst = LinkedList::new();
 
@@ -220,9 +221,9 @@ impl<T: PartialOrd + Ord + Clone> BinaryTree<T> {
         match start {
             None => {},
             Some(node) => {
-                BinaryTree::sub_flatten(&node.left, list);
-                list.push(node.value.clone());
                 BinaryTree::sub_flatten(&node.right, list);
+                list.push(node.value.clone());
+                BinaryTree::sub_flatten(&node.left, list);
             },
         }
     }
@@ -323,5 +324,20 @@ mod tests {
             Ok(min) => assert_eq!(min, &20),
             Err(err) => panic!("Next min value search is not working, {}", err),
         }
+    }
+
+    #[test]
+    fn bst_iter() {
+        let mut bst = BinaryTree::new();
+        bst.push(5); bst.push(6); bst.push(17); bst.push(10); bst.push(2);
+
+        let flat_bst = bst.flatten();
+        let mut flat_bst_iter = flat_bst.iter();
+
+        assert_eq!(flat_bst_iter.next(), Some(&2));
+        assert_eq!(flat_bst_iter.next(), Some(&5));
+        assert_eq!(flat_bst_iter.next(), Some(&6));
+        assert_eq!(flat_bst_iter.next(), Some(&10));
+        assert_eq!(flat_bst_iter.next(), Some(&17));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ impl Error for NullError {}
 pub struct LinkedList<T> {
     head: Link<T>,
     count: usize,
+    last: Link<T>,
 }
 
 type Link<T> = Option<Box<Node<T>>>;
@@ -40,6 +41,7 @@ impl<T> LinkedList<T> {
         LinkedList { 
             head: None,
             count: 0, 
+            last: None,
         }
     }
 
@@ -55,55 +57,39 @@ impl<T> LinkedList<T> {
 
         self.head = Some(new_node);
         self.count = self.count + 1;
+        self.last = new_node.next;
     }
 
     pub fn count(&self) -> &usize {
         &self.count
     }
 
-    //WIP - need to get to the end of self or list!
-    pub fn merge(&mut self, mut list: LinkedList<T>) {
-        match list.head {
-            None => {},
+    //WIP - rewrite into sane function
+    pub fn merge(&mut self, list: LinkedList<T>) {
+        match &list.head {
+            None => return,
             Some(list_node) => {
-                let mut last = LinkedList::last(list.head);
-
-                match last {
-                    Err(NullError) => {},
-                    Ok(node) => {
-                        node.unwrap().next = list.head;
+                match &self.last {
+                    None => return,
+                    Some(node) => {
+                        node.next = list.head;
                         self.count = self.count + list.count;
-                    }
+                    },
                 }
-            }
+            },
         }
     }
 
-    fn last(head: Link<T>) -> Result<Link<T>, NullError> {
-        let mut current_link = head;
-
-        match current_link {
-            None => Err(NullError{}),
-            Some(node) => {
-                loop {
-                    match node.next {
-                        None => return Ok(current_link),
-                        Some(node) => current_link = node.next,
-                    }
-                }
-            }
-        }
-    }
-
+    //WIP - modify last accordingly
     pub fn pop(&mut self) -> Option<T> {
         match std::mem::replace(&mut self.head, None) {
             None => None,
             Some(node) => {
                 self.head = node.next;
+                self.count = self.count - 1;
                 Some(node.value)
-            }
+            },
         }
-
     }
     
     pub fn iter(&self) -> Iter<'_, T> {
@@ -293,9 +279,9 @@ mod tests {
         let mut list:LinkedList<i32> = LinkedList::new();
         list.push(32); list.push(33); list.push(34);
 
-        match list.last() {
-            None => { panic!("Getting last list node is not working") },
-            Some(node) => { assert_eq!(node.value,&32) },
+        match list.last {
+            None => panic!("Getting last list node is not working"),
+            Some(node) => assert_eq!(node.value, &32),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,31 +290,6 @@ mod tests {
         }
     }
 
-    //remove later
-    #[test]
-    fn find_next_min_value_in_bst() {
-        let mut bst = BinaryTree::new();
-        bst.push(5); bst.push(6); bst.push(17); bst.push(10); bst.push(2);
-
-        match BinaryTree::sub_min_with_limit(&bst.head, &5, &5) {
-            Ok(min) => assert_eq!(min, &6),
-            Err(err) => panic!("Next min value search is not working, {}", err),
-        }
-    }
-
-    #[test]
-    fn find_min_value_in_bst_complex() {
-        let mut bst = BinaryTree::new();
-        bst.push(20); bst.push(15); bst.push(17); bst.push(16); bst.push(19);
-        bst.push(9); bst.push(12); bst.push(10); bst.push(6); bst.push(5);
-        bst.push(21); bst.push(25); bst.push(23); bst.push(28); bst.push(40);
-
-        match BinaryTree::sub_min_with_limit(&bst.head, &19, &19) {
-            Ok(min) => assert_eq!(min, &20),
-            Err(err) => panic!("Next min value search is not working, {}", err),
-        }
-    }
-
     #[test]
     fn bst_iter() {
         let mut bst = BinaryTree::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,13 @@ impl<T: PartialOrd + Ord + Clone> BinaryTree<T> {
         
     }
 
+    pub fn is_empty(&self) -> bool {
+        match &self.head {
+            None => true,
+            Some(node) => false,
+        }
+    }
+
     fn insert(node: &mut BinaryTreeNode<T>, value: T) {
         if node.value > value {
             match &mut node.left {
@@ -188,28 +195,10 @@ impl<T: PartialOrd + Ord + Clone> BinaryTree<T> {
         }
     }
 
-    fn sub_min_with_limit<'a>(head: &'a BinaryTreeLink<T>, min: &'a T, bottom_limit: &T) -> Result<&'a T, NullError> {
-        let left_min: &T;
-        let right_min: &T;
-        
-        match &head { 
-            None => Ok(&min),
-            Some(bst_node) => {
-                if &bst_node.value > bottom_limit { 
-                    left_min = BinaryTree::sub_min_with_limit(&bst_node.left, &bst_node.value, bottom_limit).unwrap();
-                    right_min = BinaryTree::sub_min_with_limit(&bst_node.right, &bst_node.value, bottom_limit).unwrap();
-
-                    Ok(BinaryTree::lesser_node(left_min, right_min))
-                }
-                else {  BinaryTree::sub_min_with_limit(&bst_node.right, min, bottom_limit) }
-            }
-        }
-    }
-
     //Iterator workaround
     //Creates linked list with references to binary search tree ordered from min to max
-    //To achieve this Binary tree traversal is done in Reverse order 
-    //Because LinkedList push implementation adds new nodes atop, not in the end of List
+    //To achieve this, Binary tree traversal is done in Reverse order 
+    //Because LinkedList push implementation adds new nodes atop, not at the end of List
     pub fn flatten(&self) -> LinkedList<T> {
         let mut flattened_bst = LinkedList::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ impl Error for NullError {}
 
 pub struct LinkedList<T> {
     head: Link<T>,
+    count: usize,
 }
 
 type Link<T> = Option<Box<Node<T>>>;
@@ -36,14 +37,14 @@ struct Node<T> {
 
 impl<T> LinkedList<T> {
     pub fn new() -> Self {
-        LinkedList { head: None }
+        LinkedList { 
+            head: None,
+            count: 0, 
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        match &self.head {
-            Some(node) => false,
-            None => true,
-        }
+        self.count > 0
     }
 
     pub fn push(&mut self, value: T) {
@@ -53,6 +54,11 @@ impl<T> LinkedList<T> {
         });
 
         self.head = Some(new_node);
+        self.count = self.count + 1;
+    }
+
+    pub fn count(&self) -> &usize {
+        &self.count
     }
 
     pub fn pop(&mut self) -> Option<T> {
@@ -200,6 +206,13 @@ impl<T: PartialOrd + Ord> BinaryTree<T> {
         }
     }
 
+    //WIP
+    //Creates linked list with references to binary search tree ordered from min to max
+    //Iterator workaround
+    pub fn flatten(&self) -> LinkedList<&T> {
+        LinkedList::new()
+    }
+
     fn generate_node(value: T) -> Box<BinaryTreeNode<T>> {
         Box::new(BinaryTreeNode {
             value: value,
@@ -231,6 +244,14 @@ mod tests {
         list.push(32);
 
         assert_eq!(list.pop(), Some(32));
+    }
+
+    #[test]
+    fn list_node_count() {
+        let mut list:LinkedList<i32> = LinkedList::new();
+        list.push(32); list.push(32); list.push(32);
+
+        assert_eq!(list.count(), &3);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ impl Error for NullError {}
 pub struct LinkedList<T> {
     head: Link<T>,
     count: usize,
-    last: Link<T>,
 }
 
 type Link<T> = Option<Box<Node<T>>>;
@@ -41,7 +40,6 @@ impl<T> LinkedList<T> {
         LinkedList { 
             head: None,
             count: 0, 
-            last: None,
         }
     }
 
@@ -57,30 +55,12 @@ impl<T> LinkedList<T> {
 
         self.head = Some(new_node);
         self.count = self.count + 1;
-        self.last = new_node.next;
     }
 
     pub fn count(&self) -> &usize {
         &self.count
     }
 
-    //WIP - rewrite into sane function
-    pub fn merge(&mut self, list: LinkedList<T>) {
-        match &list.head {
-            None => return,
-            Some(list_node) => {
-                match &self.last {
-                    None => return,
-                    Some(node) => {
-                        node.next = list.head;
-                        self.count = self.count + list.count;
-                    },
-                }
-            },
-        }
-    }
-
-    //WIP - modify last accordingly
     pub fn pop(&mut self) -> Option<T> {
         match std::mem::replace(&mut self.head, None) {
             None => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,40 @@ impl<T> LinkedList<T> {
         &self.count
     }
 
+    //WIP - need to get to the end of self or list!
+    pub fn merge(&mut self, mut list: LinkedList<T>) {
+        match list.head {
+            None => {},
+            Some(list_node) => {
+                let mut last = LinkedList::last(list.head);
+
+                match last {
+                    Err(NullError) => {},
+                    Ok(node) => {
+                        node.unwrap().next = list.head;
+                        self.count = self.count + list.count;
+                    }
+                }
+            }
+        }
+    }
+
+    fn last(head: Link<T>) -> Result<Link<T>, NullError> {
+        let mut current_link = head;
+
+        match current_link {
+            None => Err(NullError{}),
+            Some(node) => {
+                loop {
+                    match node.next {
+                        None => return Ok(current_link),
+                        Some(node) => current_link = node.next,
+                    }
+                }
+            }
+        }
+    }
+
     pub fn pop(&mut self) -> Option<T> {
         match std::mem::replace(&mut self.head, None) {
             None => None,
@@ -252,6 +286,31 @@ mod tests {
         list.push(32); list.push(32); list.push(32);
 
         assert_eq!(list.count(), &3);
+    }
+
+    #[test]
+    fn last_node() {
+        let mut list:LinkedList<i32> = LinkedList::new();
+        list.push(32); list.push(33); list.push(34);
+
+        match list.last() {
+            None => { panic!("Getting last list node is not working") },
+            Some(node) => { assert_eq!(node.value,&32) },
+        }
+    }
+
+    #[test]
+    fn list_merge() {
+        let mut legacy:LinkedList<i32> = LinkedList::new();
+        let mut hype:LinkedList<i32> = LinkedList::new();
+
+        legacy.push(1); hype.push(2); hype.push(3);
+        legacy.merge(hype);
+
+        let mut legacy_iter = legacy.iter();
+        assert_eq!(legacy_iter.next(), Some(&1));
+        assert_eq!(legacy_iter.next(), Some(&2));
+        assert_eq!(legacy.count, &3);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ struct BinaryTreeNode<T> {
     left: BinaryTreeLink<T>,
 }
 
-impl<T: PartialOrd + Ord> BinaryTree<T> {
+impl<T: PartialOrd + Ord + Clone> BinaryTree<T> {
     pub fn new() -> Self {
         BinaryTree { head: None }
     }
@@ -209,8 +209,22 @@ impl<T: PartialOrd + Ord> BinaryTree<T> {
     //WIP
     //Creates linked list with references to binary search tree ordered from min to max
     //Iterator workaround
-    pub fn flatten(&self) -> LinkedList<&T> {
-        LinkedList::new()
+    pub fn flatten(&self) -> LinkedList<T> {
+        let mut flattened_bst = LinkedList::new();
+
+        BinaryTree::sub_flatten(&self.head, &mut flattened_bst);
+        flattened_bst
+    }
+
+    fn sub_flatten(start: &BinaryTreeLink<T>, list: &mut LinkedList<T>) {
+        match start {
+            None => {},
+            Some(node) => {
+                BinaryTree::sub_flatten(&node.left, list);
+                list.push(node.value.clone());
+                BinaryTree::sub_flatten(&node.right, list);
+            },
+        }
     }
 
     fn generate_node(value: T) -> Box<BinaryTreeNode<T>> {
@@ -252,31 +266,6 @@ mod tests {
         list.push(32); list.push(32); list.push(32);
 
         assert_eq!(list.count(), &3);
-    }
-
-    #[test]
-    fn last_node() {
-        let mut list:LinkedList<i32> = LinkedList::new();
-        list.push(32); list.push(33); list.push(34);
-
-        match list.last {
-            None => panic!("Getting last list node is not working"),
-            Some(node) => assert_eq!(node.value, &32),
-        }
-    }
-
-    #[test]
-    fn list_merge() {
-        let mut legacy:LinkedList<i32> = LinkedList::new();
-        let mut hype:LinkedList<i32> = LinkedList::new();
-
-        legacy.push(1); hype.push(2); hype.push(3);
-        legacy.merge(hype);
-
-        let mut legacy_iter = legacy.iter();
-        assert_eq!(legacy_iter.next(), Some(&1));
-        assert_eq!(legacy_iter.next(), Some(&2));
-        assert_eq!(legacy.count, &3);
     }
 
     #[test]


### PR DESCRIPTION
Added a workaround to iterate over BST - a flatten() method that returns a Linked List with ordered (from min to max) elements of BST